### PR TITLE
fix the upper constraint on the check

### DIFF
--- a/controls/RHEL-07-010220.rb
+++ b/controls/RHEL-07-010220.rb
@@ -35,7 +35,7 @@ If the “PASS_MAX_DAYS” parameter value is not 60 or less, or is commented ou
   }
   describe parse_config_file('/etc/login.defs', options) do
     its('PASS_MAX_DAYS') { should_not eq nil }
-    its('PASS_MAX_DAYS') { should_not match /[6-9][1-9]|[7-9][0-9]/ }
+    its('PASS_MAX_DAYS') { should be <= "60" }
   end
 # STOP_DESCRIBE RHEL-07-010220
 


### PR DESCRIPTION
with the regular expression check, you could set the value to 101 and the check would still pass. With this the check consistently puts an upper limit on the value